### PR TITLE
Reparametrized sampling for discrete actions and support for continuous actions

### DIFF
--- a/examples/cartpole_offline.yaml
+++ b/examples/cartpole_offline.yaml
@@ -1,4 +1,4 @@
-cartpole-experiment:
+cartpole-offline-experiment:
   env: CartPole-v0
   is_atari: false
 

--- a/examples/cartpolev0.yaml
+++ b/examples/cartpolev0.yaml
@@ -1,4 +1,4 @@
-cartpole-experiment:
+cartpolev0-experiment:
   env: CartPole-v0
   is_atari: false
 

--- a/examples/pendulum.yaml
+++ b/examples/pendulum.yaml
@@ -1,0 +1,12 @@
+cartpole-experiment:
+  env: Pendulum-v1
+  is_atari: false
+
+  model_dimension: XS
+
+  training_ratio: 1024
+
+  summary_frequency_train_steps: 10
+  evaluation_frequency_main_iters:  20
+  evaluation_num_episodes: 10
+  model_save_frequency_main_iters: 1000

--- a/examples/pendulum.yaml
+++ b/examples/pendulum.yaml
@@ -1,4 +1,4 @@
-cartpole-experiment:
+pendulum-experiment:
   env: Pendulum-v1
   is_atari: false
 

--- a/examples/pendulum_offline.yaml
+++ b/examples/pendulum_offline.yaml
@@ -1,0 +1,13 @@
+cartpole-experiment:
+  env: Pendulum-v1
+  is_atari: false
+
+  model_dimension: XS
+
+  num_pretrain_iterations: 10000
+  training_ratio: 1024
+
+  summary_frequency_train_steps: 20
+  evaluation_frequency_main_iters: 0
+  evaluation_num_episodes: 0
+  model_save_frequency_main_iters: 1000

--- a/examples/pendulum_offline.yaml
+++ b/examples/pendulum_offline.yaml
@@ -1,4 +1,4 @@
-cartpole-experiment:
+pendulum-offline-experiment:
   env: Pendulum-v1
   is_atari: false
 

--- a/examples/run_experiment.py
+++ b/examples/run_experiment.py
@@ -427,7 +427,7 @@ for iteration in range(1000000):
                     "a_one_hot": sample["actions_one_hot"][:, 0],
                 },
                 sample["obs"][:, 0],
-                is_first=sample["is_first"][:, 0],
+                sample["is_first"][:, 0],
             )
             world_model.summary()
 

--- a/examples/run_experiment.py
+++ b/examples/run_experiment.py
@@ -425,6 +425,7 @@ for iteration in range(1000000):
                     "a_one_hot": sample["actions_one_hot"][:, 0],
                 },
                 sample["obs"][:, 0],
+                is_first=sample["is_first"][:, 0],
             )
             world_model.summary()
 

--- a/losses/actor_loss.py
+++ b/losses/actor_loss.py
@@ -28,8 +28,7 @@ def actor_loss(
     actions_dreamed = dream_data["actions_dreamed_t0_to_H_B"][:-1]
     # Log(p)s of all possible actions in the dream.
     # Note that when we create the Categorical action distributions, we compute
-    # unimix probs, then math.log these and provide these log(p) as "logits" to the
-    # Categorical. So here, we'll continue to work with log(p)s (not really "logits")!
+    # unimix probs
     logp_actions_t0_to_Hm1_B = tf.stack(
         [dist.logits
          for dist in dream_data["actions_dreamed_distributions_t0_to_H_B"][:-1]

--- a/losses/actor_loss.py
+++ b/losses/actor_loss.py
@@ -28,7 +28,8 @@ def actor_loss(
     actions_dreamed = dream_data["actions_dreamed_t0_to_H_B"][:-1]
     # Log(p)s of all possible actions in the dream.
     # Note that when we create the Categorical action distributions, we compute
-    # unimix probs
+    # unimix probs, then math.log these and provide these log(p) as "logits" to the
+    # Categorical. So here, we'll continue to work with log(p)s (not really "logits")!
     logp_actions_t0_to_Hm1_B = tf.stack(
         [dist.logits
          for dist in dream_data["actions_dreamed_distributions_t0_to_H_B"][:-1]

--- a/losses/actor_loss.py
+++ b/losses/actor_loss.py
@@ -5,6 +5,7 @@ https://arxiv.org/pdf/2301.04104v1.pdf
 """
 import tensorflow as tf
 import tensorflow_probability as tfp
+from gymnasium.spaces import Discrete, Box
 
 
 @tf.function
@@ -39,7 +40,12 @@ def actor_loss(
     )
     # First term of loss function.
     # [1] eq. 11.
-    logp_loss_B_H = logp_actions_dreamed_B_H * scaled_value_targets_B_H
+    if isinstance(actor.action_space, Discrete):
+        logp_loss_B_H = logp_actions_dreamed_B_H * tf.stop_gradient(scaled_value_targets_B_H)
+    elif isinstance(actor.action_space, Box):
+        logp_loss_B_H = scaled_value_targets_B_H
+    else:
+        raise ValueError(f"Invalid action space: {actor.action_space}")
     assert len(logp_loss_B_H.shape) == 2
     # Add entropy loss term (second term [1] eq. 11).
     entropy_B_H = tf.stack(

--- a/losses/actor_loss.py
+++ b/losses/actor_loss.py
@@ -30,6 +30,7 @@ def actor_loss(
     actions_dreamed = tf.stop_gradient(dream_data["actions_dreamed_t0_to_H_B"][:-1])
     # Compute Log(p)s of all possible actions in the dream.
     dist_actions_t0_to_Hm1_B = dream_data["actions_dreamed_distributions_t0_to_H_B"][:-1]
+    # TODO (Rohan138, Sven): Figure out how to vectorize this instead!
     logp_actions_dreamed_t0_to_Hm1_B = tf.stack([
         dist.log_prob(action) for dist, action in 
         zip(dist_actions_t0_to_Hm1_B, actions_dreamed)

--- a/models/components/actor_network.py
+++ b/models/components/actor_network.py
@@ -17,7 +17,7 @@ class ReparametrizedCategorical(tfp.distributions.Categorical):
     def sample(self, sample_shape=(), seed=None):
         action = super().sample(sample_shape, seed)
         # Convert from integer to onehot
-        action = tf.one_hot(action, depth=len(self.logits), axis=-1)
+        action = tf.one_hot(action, depth=self.logits.shape[-1], axis=-1)
         # Add reparamtrized probs to actions; will compute straight-through gradients
         probs = tf.exp(self.logits)
         action = tf.stop_gradient(action) + tf.cast(probs - tf.stop_gradient(probs), action.dtype)
@@ -119,9 +119,10 @@ if __name__ == "__main__":
     action_space = gym.spaces.Discrete(5)
     print("action space: ", action_space)
 
+    b_dim = 2
     h_dim = 8
-    h = np.random.random(size=(1, 8))
-    z = np.random.random(size=(1, 8, 8))
+    h = np.random.random(size=(b_dim, h_dim))
+    z = np.random.random(size=(b_dim, h_dim, h_dim))
 
     model = ActorNetwork(action_space=action_space, model_dimension="XS")
 
@@ -134,10 +135,6 @@ if __name__ == "__main__":
 
     action_space = gym.spaces.Box(0, 1, (5,))
     print("action space: ", action_space)
-
-    h_dim = 8
-    h = np.random.random(size=(1, 8))
-    z = np.random.random(size=(1, 8, 8))
 
     model = ActorNetwork(action_space=action_space, model_dimension="XS")
 


### PR DESCRIPTION
Noticed a possible major difference between our implementation and Danijar's: he uses reparametrized sampling to get actions from the onehot categorical. https://github.com/danijar/dreamerv3/blob/main/dreamerv3/nets.py#L495
https://github.com/danijar/dreamerv3/blob/main/dreamerv3/jaxutils.py#L77

Per the tensorflow docs, the Categorical dist is not originally reparametrized, so we should probably duplicate this to stabilize the actor learning.
```
import tensorflow_probability as tfp
tfd = tfp.distributions
dist = tfd.Categorical([0.1, 0.4, 0.5])
dist.reparameterization_type == tfd.NOT_REPARAMETERIZED
```
https://www.tensorflow.org/probability/api_docs/python/tfp/distributions/ReparameterizationType

Also, I implemented support for continuous actions; still testing on Pendulum.